### PR TITLE
Fix on Build-debs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ pipeline:
     privileged: true
     commands:
       - apt-get update
-      - apt-get install --yes --no-install-recommends libusb-1.0-0-dev cdbs texinfo texlive libjim-dev 
+      - apt-get install --yes --no-install-recommends libusb-1.0-0-dev cdbs texinfo texlive libjim-dev pkgconf
       - ./bootstrap && ./configure && debuild -us -uc -b
       - mv ../*.deb .
 

--- a/bootstrap
+++ b/bootstrap
@@ -24,11 +24,11 @@ fi
 # bootstrap the autotools
 (
 set -x
+${libtoolize} --force --automake --copy
 aclocal
-${libtoolize} --automake --copy
-autoconf
 autoheader
-automake --gnu --add-missing --copy
+automake --force-missing --add-missing --gnu --copy
+autoconf
 )
 
 if [ -n "$SKIP_SUBMODULE" ]; then


### PR DESCRIPTION
When drone tried to build the packages two errors appeared:

1.  `configure.ac:12: error: possibly undefined macro: AC_MSG_WARN
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
configure.ac:240: error: possibly undefined macro: AC_MSG_NOTICE
configure.ac:342: error: possibly undefined macro: AC_DEFINE`
2. `./configure: line 4533: syntax error near unexpected token `0.23'
./configure: line 4533: `PKG_PROG_PKG_CONFIG(0.23)'` 
For the first error i had updated the bootstrap file, adding the flag --force on the libtoolize and --force-missing on automake. I've also rearranged the steps.
For the second error i update the build-debs step on drone file to install the package `pkgconf`